### PR TITLE
Fix dozens of warnings in log:

### DIFF
--- a/cptc.Dockerfile
+++ b/cptc.Dockerfile
@@ -17,7 +17,7 @@ ENV Z88DK_PATH="/opt/z88dk" \
 
 RUN apt-get update
 
-RUN export DEBIAN_FRONTEND=noninteractive \
+RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get install -y tzdata \
     && ln -fs /usr/share/zoneinfo/Europe/Brussels /etc/localtime \
     && dpkg-reconfigure --frontend noninteractive tzdata \


### PR DESCRIPTION
Solves issue #1 .

```
debconf: unable to initialize frontend: Noninteractive
debconf: (Unrecognized character \xC2; marked by <-- HERE after nteractive<-- HERE near column 42 at (eval 18) line 2.)
debconf: falling back to frontend: Noninteractive
```